### PR TITLE
Patch to geostubbing

### DIFF
--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -131,6 +131,7 @@ Then /^I should be on the sign in page$/ do
 end
 
 When /^I edit the charity address to be "(.*?)"$/ do |address|
+   stub_request_with_address(address)
    fill_in('organization_address',:with => address)
 end
 


### PR DESCRIPTION
Now we can edit in address changes after organization is created even if the address was never used before, as long as it is in the the json subfolder
