### PR TITLE
Work on refactoring organization controller specs

### DIFF
--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -153,8 +153,9 @@ describe OrganizationsController do
   describe "POST create" do
     context "while signed in" do
       before(:each) do
-        @user = FactoryGirl.create(:user)
-        sign_in :user, @user
+        user = mock_model("User")
+        request.env['warden'].stub :authenticate! => user
+        controller.stub!(:current_user).and_return(user)
       end
 
       describe "with valid params" do
@@ -196,20 +197,17 @@ describe OrganizationsController do
   end
 
   describe "PUT update" do
-    context "while signed in as admin" do
+    context "while signed in as user who can edit" do
       before(:each) do
-        @admin = FactoryGirl.create(:user, :admin => true)
-        sign_in :user, @admin
+        user = mock_model("User")
+        user.stub!(:can_edit?){true}
+        request.env['warden'].stub :authenticate! => user
+        controller.stub!(:current_user).and_return(user)
       end
 
       describe "with valid params" do
-        it "updates the requested organization" do
-          Organization.should_receive(:find).with("37") { mock_organization }
-          mock_organization.should_receive(:update_attributes).with({'these' => 'params'})
-          put :update, :id => "37", :organization => {'these' => 'params'}
-        end
 
-        it "updates donation_info url" do
+        it "updates org for e.g. donation_info url" do
           mock = mock_organization(:id => 37)
           Organization.should_receive(:find).with("37"){mock}
           mock_organization.should_receive(:update_attributes).with({'donation_info' => 'http://www.friendly.com/donate'})
@@ -244,61 +242,35 @@ describe OrganizationsController do
       end
     end
 
-    context "while signed in as normal user belonging to organization" do
+    context "while signed in as user who cannot edit" do
       before(:each) do
-        #TODO: Is this necessary to push into real database to get the association to take?
-        @user = FactoryGirl.create(:user_stubbed_organization)
-        #TODO ultimately the controller spec shouldn't need to care about whether a user is an admin
-        #TODO or the person responsible for a charity, that should be refactored into User spec
-        @associated_org = @user.organization
-        sign_in :user, @user
+        user = mock_model("User")
+        user.stub!(:can_edit?){false}
+        request.env['warden'].stub :authenticate! => user
+        controller.stub!(:current_user).and_return(user)
       end
 
-      describe "with valid params" do
-        it "updates the requested organization" do
-          Organization.should_receive(:find).with("#{@associated_org.id}"){@associated_org}
-          @associated_org.should_receive(:update_attributes).with({'these' => 'params'})
-          put :update, :id => "#{@associated_org.id}", :organization => {'these' => 'params'}
-        end
-        it "updates donation_info url" do
-          org = @user.organization
-          Organization.should_receive(:find).with("#{@associated_org.id}"){@associated_org}
-         @associated_org.should_receive(:update_attributes).with({'donation_info' => 'http://www.friendly.com/donate'})
-          put :update, :id => "#{@associated_org.id}", :organization => {'donation_info' => 'http://www.friendly.com/donate'}
-        end
-      end
-    end
-
-    context "while signed in as normal user belonging to no organization" do
-      before(:each) do
-        @user = FactoryGirl.create(:user)
-        @non_associated_org = mock_organization
-        sign_in :user, @user
-        expect(@user.organization).to eq(nil)
-        expect(@user.admin?).to eq(false)
-      end
-
-      describe "with valid params" do
+      describe "with existing organization" do
         it "does not update the requested organization" do
-          Organization.should_receive(:find).with("#{@non_associated_org.id}")  {@non_associated_org}
-          @non_associated_org.should_not_receive(:update_attributes)
-          put :update, :id => "#{@non_associated_org.id}", :organization => {'these' => 'params'}
-          response.should redirect_to(organization_url("#{@non_associated_org.id}"))
+          org = mock_organization(:id => 37)
+          Organization.should_receive(:find).with("#{org.id}")  {org}
+          org.should_not_receive(:update_attributes)
+          put :update, :id => "#{org.id}", :organization => {'these' => 'params'}
+          response.should redirect_to(organization_url("#{org.id}"))
           expect(flash[:notice]).to eq("You don't have permission")
         end
       end
 
-      describe "with invalid params" do
+      describe "with non-existent organization" do
         it "does not update the requested organization" do
           Organization.should_receive(:find).with("9999")  {nil}
-          @non_associated_org.should_not_receive(:update_attributes)
           put :update, :id => "9999", :organization => {'these' => 'params'}
           response.should redirect_to(organization_url("9999"))
           expect(flash[:notice]).to eq("You don't have permission")
         end
       end
-
     end
+    
     context "while not signed in" do
       it "redirects to sign-in" do
         put :update, :id => "1", :organization => {'these' => 'params'}
@@ -310,8 +282,10 @@ describe OrganizationsController do
   describe "DELETE destroy" do
     context "while signed in as admin" do
       before(:each) do
-        @user = FactoryGirl.create(:user, :admin => true)
-        sign_in :user, @user
+        user = mock_model("User")
+        user.stub!(:admin?){true}
+        request.env['warden'].stub :authenticate! => user
+        controller.stub!(:current_user).and_return(user)
       end
       it "destroys the requested organization" do
         Organization.should_receive(:find).with("37") { mock_organization }
@@ -327,8 +301,10 @@ describe OrganizationsController do
     end
     context "while signed in as non-admin" do
       before(:each) do
-        @user = FactoryGirl.create(:user)
-        sign_in :user, @user
+        user = mock_model("User")
+        user.stub!(:admin?){false}
+        request.env['warden'].stub :authenticate! => user
+        controller.stub!(:current_user).and_return(user)
       end
       it "does not destroy the requested organization" do
         mock = mock_organization


### PR DESCRIPTION
The result of our pairing that isolated controller specs from user model and used can_edit? where appropriate given current state of the app
