### PR TITLE
Ignore Emacs backup files - which Emacs makes when it doesn't have a git...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ pickle-email-*.html
 .DS_Store
 linecache19-0.5.13.gem
 /bin/
+\#*#
+\.#*


### PR DESCRIPTION
... aware package, such as magit, loaded
