### PR TITLE
Remove the explicit ruby requirement in Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'http://rubygems.org'
 
+ruby '2.0.0'
 gem 'rails', '3.2.14'
 gem 'devise'
 


### PR DESCRIPTION
Shall we try letting go of Ruby 1.9? Ruby 2 works with Rails 3.2, for
some time now, so it seems stable:
https://github.com/rails/rails/pull/9406

Motivation: It might be better to avoid forcing beginners -- coming to
this beginner-friendly project -- to use the older Ruby version, from
the get-go.

In LocalSupport specifically, after removing this line from the
Gemfile, the unit tests still all pass and clicking around a bit, the
site renders well blackbox-wise too.
