### PR TITLE
Refactor: Remove duplication 

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -94,16 +94,8 @@ class Organization < ActiveRecord::Base
   end
 
   def self.import_category_mappings(filename, limit)
-    csv_text = File.open(filename, 'r:ISO-8859-1')
-    count = 0
-    CSV.parse(csv_text, :headers => true).each do |row|
-      break if count >= limit
-      count += 1
-      begin
-        self.import_categories_from_array(row)  #  <--- yield
-      rescue CSV::MalformedCSVError => e
-        logger.error(e.message)
-      end
+    import(filename, limit, false) do |row, validation| 
+      import_categories_from_array(row) 
     end
   end
 
@@ -112,13 +104,19 @@ class Organization < ActiveRecord::Base
   end
 
   def self.import_addresses(filename, limit, validation = true)
+    import(filename, limit, validation) do |row, validation| 
+       create_from_array(row, validation) 
+    end
+  end
+
+  def self.import(filename, limit, validation, &block)
     csv_text = File.open(filename, 'r:ISO-8859-1')
     count = 0
     CSV.parse(csv_text, :headers => true).each do |row|
       break if count >= limit
       count += 1
       begin
-        self.create_from_array(row, validation)  #  <--- yield
+        yield(row, validation)
       rescue CSV::MalformedCSVError => e
         logger.error(e.message)
       end


### PR DESCRIPTION
Removed the duplication between 

```
Organization.import_category_mappings
```

and

```
Organization.import_addresses
```

This was one of the simple refactoring that we talked about in today's refactoring session.
