### PR TITLE
import rake task has monkeypatched remove_error_with address method that doesn't nullify coordinates

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -3,7 +3,22 @@ begin
     namespace :import do
       task :emails, [:file] => :environment do |t, args|
         # pass variables like so bundle exec rake db:import:emails[db/emails.csv]
-        #Organization.set_gmaps4rails_options!({ :check_process  => true })
+        #Organization.acts_as_gmappable({ :check_process  => true })
+        require File.expand_path("../../config/environment", File.dirname(__FILE__))
+        #class Organization
+        #private
+        Organization.instance_eval do
+          private :remove_errors_with_address do
+            errors_hash = errors.to_hash
+            errors.clear
+            errors_hash.each do |key, value|
+              logger.warn "#{key} --> #{value}"
+              if key.to_s != 'gmaps4rails_address'
+                errors.add(key, value)
+              end
+            end
+          end
+        end
         Organization.import_emails(args[:file],1000)
       end
     end


### PR DESCRIPTION
This seems to be superficially the way to go

We want in the long run to be able to avoid geocoding when it makes sense but this solves the immediate problem of the rake db:import:emails task blanking out a bunch of addresses on the map because of rate limiting.
