### PR TITLE
This feels really hacky

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -3,12 +3,13 @@ begin
     namespace :import do
       task :emails, [:file] => :environment do |t, args|
         # pass variables like so bundle exec rake db:import:emails[db/emails.csv]
-        #Organization.acts_as_gmappable({ :check_process  => true })
         require File.expand_path("../../config/environment", File.dirname(__FILE__))
-        #class Organization
-        #private
-        Organization.instance_eval do
-          private :remove_errors_with_address do
+        #this is needed because rake tasks load classes lazily; from the command line, the task will
+        #otherwise fail because it takes the below intended monkeypatch as first definition
+        Organization.to_s
+        class Organization
+          private 
+          def remove_errors_with_address
             errors_hash = errors.to_hash
             errors.clear
             errors_hash.each do |key, value|


### PR DESCRIPTION
But the virtue is it works.

We want to make geocoding not happen at all when it doesn't make sense but that will take more research and possibly refactorings.

The sin is that it couples the rake task monkey patch with the monkey patch in organization.

Oh, and don't remove the to_s call or face the wrath of lazy loading on the rake command line.
