### PR TITLE
run_geocode? rspec coverage

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,7 +8,6 @@ end
 
 class Organization < ActiveRecord::Base
   # http://stackoverflow.com/questions/10738537/lazy-geocoding
-  # lambda { |org| !org.address.blank? && org.latitude.blank? && org.longitude.blank? }
   acts_as_gmappable :check_process => false, :process_geocoding => :run_geocode?
   has_many :users
   has_and_belongs_to_many :categories
@@ -17,8 +16,7 @@ class Organization < ActiveRecord::Base
   attr_accessible :name, :description, :address, :postcode, :email, :website, :telephone, :donation_info
   accepts_nested_attributes_for :users
 
-  # if we removed check_process => false saving the model would not trigger
-  # a geocode
+  # if we removed check_process => false saving the model would not trigger a geocode
   #after_commit :process_geocoding
 
   def run_geocode?

--- a/spec/models/geocode_spec.rb
+++ b/spec/models/geocode_spec.rb
@@ -32,24 +32,49 @@ describe Organization do
     @org1.longitude.should eq nil
   end
 
-  it 'no geocoding allowed when saving if the org already has an address and coordinates' do
-    Gmaps4rails.should_not_receive(:geocode)
-    @org2.email = 'something@example.com'
-    @org2.save!
+  describe 'run_geocode?' do
+    it 'should return true if address is changed' do
+      @org1.address = "asjkdhas,ba,asda"
+      @org1.run_geocode?.should be_true
+    end
+
+    it 'should return false if address is not changed' do
+      @org1.run_geocode?.should be_true
+    end
+
+    it 'should return false if org has no address' do
+      org = Organization.new
+      org.run_geocode?.should be_false
+    end
+
+    it 'should return true if org has an address but no coordinates' do
+      @org1.run_geocode?.should be_true
+    end
+
+    it 'should return false if org has an address and coordinates' do
+      @org2.run_geocode?.should be_false
+    end
   end
 
-  # it will try to rerun incomplete geocodes, but not valid ones, so no harm is done
-  it 'geocoding allowed when saving if the org has an address BUT NO coordinates' do
-    Gmaps4rails.should_receive(:geocode)
-    @org2.longitude = nil ; @org2.latitude = nil
-    @org2.email = 'something@example.com'
-    @org2.save!
-  end
+  describe "acts_as_gmappable's behavior is curtailed by the { :process_geocoding => :run_geocode? } option" do
+    it 'no geocoding allowed when saving if the org already has an address and coordinates' do
+      Gmaps4rails.should_not_receive(:geocode)
+      @org2.email = 'something@example.com'
+      @org2.save!
+    end
 
-  it 'geocoding allowed when saving if the org address changed' do
-    Gmaps4rails.should_receive(:geocode)
-    @org2.address = '777 pinner road'
-    @org2.save!
-  end
+    # it will try to rerun incomplete geocodes, but not valid ones, so no harm is done
+    it 'geocoding allowed when saving if the org has an address BUT NO coordinates' do
+      Gmaps4rails.should_receive(:geocode)
+      @org2.longitude = nil ; @org2.latitude = nil
+      @org2.email = 'something@example.com'
+      @org2.save!
+    end
 
+    it 'geocoding allowed when saving if the org address changed' do
+      Gmaps4rails.should_receive(:geocode)
+      @org2.address = '777 pinner road'
+      @org2.save!
+    end
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -415,15 +415,4 @@ describe Organization do
     end
   end
 
-  describe "run_geocode" do
-    it 'should return true if address is changed' do
-      @org1.address = "asjkdhas,ba,asda"
-      @org1.run_geocode?.should be_true
-    end
-    it 'should return false when no address is set' do
-      org = Organization.new
-      org.run_geocode?.should be_false
-    end
-  end
-
 end


### PR DESCRIPTION
- Moved Sam's rspec tests to `geocode_spec.rb`
- As per Sam's recommendation, added unit tests to cover all possible branches of conditionals in `run_geocode?`.
- Reclassified my existing rspec tests as integration tests, checking that adding option `:process_geocoding => :run_geocode?` properly curtails the behavior of `acts_as_gmappable`,
