### PR TITLE
DRYed out some cuke steps and moved some steps for nav consistency

### DIFF
--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -9,7 +9,7 @@ Given /^I am signed in as a charity worker (un)?related to "(.*?)"$/ do |negate,
   page.set_rack_session("warden.user.user.key" => User.serialize_into_session(user).unshift("User"))
 end
 
-Given /^I am signed in as a (non-)?admin$/ do |negate|
+Given /^I am signed in as an? (non-)?admin$/ do |negate|
   user = User.find_by_admin(negate ? false:true)
   page.set_rack_session("warden.user.user.key" => User.serialize_into_session(user).unshift("User"))
 end
@@ -73,10 +73,6 @@ When /^I sign out$/ do
   click_link 'Sign Out' 
 end
 
-Then /^I should be on the sign in page$/ do
-  current_path.should == new_user_session_path
-end
-
 Given /^I sign in as "(.*?)" with password "(.*?)"$/ do |email, password|
   fill_in "Email" , :with => email
   fill_in "Password" , :with => password
@@ -84,18 +80,15 @@ Given /^I sign in as "(.*?)" with password "(.*?)"$/ do |email, password|
 end
 
 Given /^I am on the sign in page$/ do
-  steps %Q{ 
-    Given I am on the home page
-  }
+  step "I am on the home page"
   click_link 'Org Login'
 end
 
 Given /^I am on the sign up page$/ do
-  steps %Q{ 
-    Given I am on the home page
-  }
+  step "I am on the home page"
   click_link 'New Org?'
 end
+
 When(/^I sign in as "(.*?)" with password "(.*?)" via email confirmation$/) do |email, password|
   user = User.find_by_email("#{email}")
   user.confirm!

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -6,7 +6,6 @@ Then /^I should see permission denied$/ do
   page.should have_content PERMISSION_DENIED
 end
 
-
 Then /^"(.*?)" should be a charity admin for "(.*?)" charity$/ do |email, org|
   org = Organization.find_by_name org
   usr = User.find_by_email(email)
@@ -17,15 +16,18 @@ end
 Then /^I should see the cannot add non registered user "(.*?)" as charity admin message$/ do |email|
   page.should have_content "The user email you entered,'#{email}', does not exist in the system"
 end
+
 And /^I add "(.*?)" as an admin for "(.*?)" charity$/ do |admin_email, charity|
   steps %Q{ And I am on the edit charity page for "#{charity}"}
   fill_in 'organization_admin_email_to_add', :with => admin_email
   steps %Q{
   And I press "Update Organisation"}
 end
+
 Then /^I should see the no charity admins message$/ do
   expect(page).to have_content "This organisation has no admins yet"
 end
+
 Given /^I delete "(.*?)" charity$/ do |name|
   org = Organization.find_by_name name
   page.driver.submit :delete, "/organizations/#{org.id}", {}
@@ -49,10 +51,6 @@ end
 
 Given /^PENDING/ do
   pending
-end
-
-Given /^I press "(.*?)"$/ do |button|
-  click_button(button)
 end
 
 When /^I search for "(.*?)"$/ do |text|
@@ -160,11 +158,6 @@ Given /^I update the "(.*?)"$/ do |name|
   org1.save!
 end
 
-
-When /^(?:|I )follow "([^"]*)"$/ do |link|
-    click_link(link)
-end
-
 Then /^I should not see any address or telephone information for "([^"]*?)"$/ do |name1|
   org1 = Organization.find_by_name(name1)
   page.should_not have_content org1.telephone
@@ -184,12 +177,13 @@ Then /^I should see the external website link for "(.*?)" charity$/ do |org_name
   org = Organization.find_by_name org_name
   page.should have_xpath %Q<//a[@target = "_blank" and @href = "#{org.website}" and contains(.,'#{org.website}')]>
 end
-Then /^I should see a link with text "([^"]*?)"$/ do |link|
-  page.should have_link link
-end
 
-Then /^I should not see a link with text "([^"]*?)"$/ do |link|
-  page.should_not have_link link
+Then /^I should( not)? see a link with text "([^"]*?)"$/ do |negate, link|
+  if negate
+    page.should_not have_link link
+  else
+    page.should have_link link
+  end
 end
 
 Then /^I should not see "(.*?)"$/ do |text|
@@ -244,23 +238,6 @@ def check_contact_details(name)
   org = Organization.find_by_name(name)
   page.should have_link name, :href => organization_path(org.id)
   page.should have_content smart_truncate(org.description)
-end
-
-Then /^I should be on the sign up page$/ do
-  current_path.should == new_user_registration_path
-end
-
-Then /^I should be on the organizations index page$/ do
-  current_path.should == organizations_path
-end
-
-Then /^I should be on the charity workers page$/ do
-  current_path.should == users_path
-end
-
-Then(/^I should be on the edit page for "(.*?)"$/) do |permalink|
-  pg = Page.find_by_permalink(permalink)
-  current_path.should eq( edit_page_path (pg.permalink ))
 end
 
 When /^I fill in "(.*?)" with "(.*?)"$/ do |field, value|

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -4,9 +4,34 @@ end
 And /^I select the "(.*?)" category$/ do |category|
   select(category, :from => "category[id]")
 end
-Then /^I should be on the home page$/ do
-  current_path.should == root_path()
+
+Then /^I should be on the (.*) page$/ do |location|
+  case location
+  when "home" then current_path.should == root_path()
+  when "sign up" then current_path.should == new_user_registration_path
+  when "sign in" then current_path.should == new_user_session_path
+  when "organizations index" then current_path.should == organizations_path
+  when "charity workers" then current_path.should == users_path
+  end
 end
+
+Then(/^I should be on the edit page for "(.*?)"$/) do |permalink|
+  pg = Page.find_by_permalink(permalink)
+  current_path.should eq( edit_page_path (pg.permalink ))
+end
+
+Given /^I press "(.*?)"$/ do |button|
+  click_button(button)
+end
+
+When /^I click "(.*)"$/ do |link|
+  click_link(link)
+end
+
+When /^(?:|I )follow "([^"]*)"$/ do |link|
+  click_link(link)
+end
+
 Given /^I am on the charity search page$/ do
   visit organizations_search_path
 end


### PR DESCRIPTION
Seemed like a lot of repetition in cucumber steps, so...
Refactored and DRY'd out some cuke steps. One of which was a case statement for "then i should be on ___ page"
Moved nav steps to navigation_steps to make it easier for devs to find. (e.g. "when i click on ___ link" shouldn't be in basic steps but in navigation steps)
