### PR TITLE
Fixed issue with rendering on IE8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,5 @@ gem 'redcarpet'
 
 # Adding font awesome
 gem "font-awesome-rails"
+
+

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,10 +23,18 @@
                   <div class="dropdown-menu" style="padding:17px;">
                     <label>Login:</label>
                     <%= form_for(resource, :html => { :id => "loginForm" }, :as => resource_name, :url => session_path(resource_name)) do |f| %>
-                        <div> <%= f.email_field :email, :autofocus => true, :placeholder => "you@example.com" %></div>
-
-                        <div><%= f.password_field :password, :placeholder => "password" %></div>
-
+                        <div>
+                          <!--[if lt IE 9]>
+                          <label for="user_email">Enter email</label>
+                          <![endif]-->
+                          <%= f.email_field :email, :autofocus => true, :placeholder => "you@example.com" %>
+                        </div>
+                        <div>
+                          <!--[if lt IE 9]>
+                          <label for="user_password">Enter password</label>
+                          <![endif]-->
+                          <%= f.password_field :password, :placeholder => "password" %>
+                        </div>
                         <% if devise_mapping.rememberable? -%>
                             <div><%= f.check_box :remember_me %> <%= f.label :remember_me, :style => "display: inline;" %></div>
                         <% end -%>
@@ -37,14 +45,23 @@
                     <% end %>
                     <form><a href="#" title="Some SEO stuff..." data-toggle="collapse" data-target="#register">Sign-up..</a></form>
                     <div class="collapse" id="register">
-                    <%= form_for(resource, :class => "collapse", :html => { :id => "registerForm" }, :as => resource_name, :url => registration_path(resource_name)) do |f| %>
-                        <%= devise_error_messages! %>
+                      <%= form_for(resource, :class => "collapse", :html => { :id => "registerForm" }, :as => resource_name, :url => registration_path(resource_name)) do |f| %>
+                          <%= devise_error_messages! %>
+                          <!--[if lt IE 9]>
+                          <label for="user_password">Enter email</label>
+                          <![endif]-->
                           <%= f.email_field :email, :autofocus => true, :id => 'signup_email', :name => 'user[email]', :placeholder => "you@example.com" %>
+                          <!--[if lt IE 9]>
+                          <label for="user_password">Enter password</label>
+                          <![endif]-->
                           <%= f.password_field :password, :id => 'signup_password', :name => 'user[password]', :placeholder => "password" %>
+                          <!--[if lt IE 9]>
+                          <label for="user_password">Confirm password</label>
+                          <![endif]-->
                           <%= f.password_field :password_confirmation, :id => 'signup_password_confirmation', :placeholder => 'confirm password' %>
 
-                        <div><%= f.submit "Sign up", :id => 'signup', :class => "btn btn-primary" %></div>
-                    <% end %>
+                          <div><%= f.submit "Sign up", :id => 'signup', :class => "btn btn-primary" %></div>
+                      <% end %>
                     </div>
                   </div>
                 </li>


### PR DESCRIPTION
We add labels to forms, instead of placeholders, if the user is on IE8 or older.
For some reason, some code was missing in the last pull request.
