### PR TITLE
Add .rbenv-gemsets to .gitignore to support Rbenv Gemset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ db/email_test.csv
 .ruby-version
 .ruby-gemset
 .rbenv
+.rbenv-gemsets


### PR DESCRIPTION
I use Rbenv Gemset and need to ignore this file.
