### PR TITLE
Fix unsticky cookie policy popup

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -64,7 +64,7 @@ body {
 #cookie-message {
     display: none;
     text-align: left;
-    position: fixed;  /* changed from absolute to make sticky footer */
+    position: fixed;
     z-index: 1001;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
OK I think I got this to the right branch this time. Minor fix to make cookie policy popup sticky to bottom of page.
