### PR TITLE
Cookie ajax

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
     #  format.json { render :nothing => true, :status => 200 }
     #end
 
-    redirect_to request.referer
+    redirect_to request.referer || '/'
   end
 
   private

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -64,16 +64,25 @@ describe ApplicationController do
   end
 
   describe 'allow_cookie_policy' do
-    before :each do
-      request.should_receive(:referer).and_return "/hello"
-    end
+    #before :each do
+    #  request.should_receive(:referer).and_return "/hello"
+    #end
     it 'cookie is set and redirected to referer' do
+      request.should_receive(:referer).and_return "/hello"
       response.should_receive(:set_cookie)
       get :allow_cookie_policy
       response.should redirect_to "/hello"
     end
 
+    it 'redirects to root if request referer is nil' do
+      request.should_receive(:referer).and_return nil
+      response.should_receive(:set_cookie)
+      get :allow_cookie_policy
+      response.should redirect_to '/'
+    end
+
     it 'cookie has correct key/value pair' do
+      request.should_receive(:referer).and_return "/hello"
       get :allow_cookie_policy
       response.cookies['cookie_policy_accepted'].should be_true
     end


### PR DESCRIPTION
- closing cookie policy window redirects to `request.referer`, or `/` if that is somehow nil.
