### PR TITLE
Redirects now determined by a white list of request controllers and verbs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,18 +1,36 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
+  before_filter :store_location
 
-  after_filter :store_location
+  # To prevent infinite redirect loops, only requests from white listed
+  # controllers are available in the "after sign-in redirect" feature
+  def white_listed
+    %w(
+        application
+        contributors
+        organizations
+        pages
+    )
+  end
 
+  def request_controller_is(white_listed)
+    white_listed.include? request.params['controller']
+  end
+
+  def request_verb_is_get?
+    request.env['REQUEST_METHOD'] == 'GET'
+  end
+
+  # Stores the URL if permitted
   def store_location
-    # store last url - this is needed for post-login redirect to whatever the user last visited.
-    unless request_path_matches_any_of?(blacklisted) || request.xhr?
+    if request_controller_is(white_listed) && request_verb_is_get?
       session[:previous_url] = request.path
     end
   end
 
-  #We test this functionality in sign-in tests for session_controller_spec
+  # Devise hook
+  # Returns the users to the page they were viewing before signing in
   def after_sign_in_path_for(resource)
-    store_location
     return session[:previous_url] if session[:previous_url]
     return organization_path(current_user.organization) if current_user.organization
     root_path
@@ -34,6 +52,7 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # Enforces admin-only limits
   # http://railscasts.com/episodes/20-restricting-access
   def authorize
     unless admin?
@@ -43,40 +62,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Not to be confused with the activerecord admin? method
   def admin?
     current_user.try :admin?
-  end
-
-  def sign_in_url
-    Regexp.new '/users/sign_in'
-  end
-
-  def sign_up_url
-    Regexp.new '/users/sign_up'
-  end
-
-  def sign_password
-    Regexp.new '/users/password'
-  end
-
-  def user_confirmation
-    Regexp.new '/users/confirmation'
-  end
-
-  def cookies_allow
-    Regexp.new '/cookies/allow'
-  end
-
-  def request_path_includes?(url)
-    url =~ request.path
-  end
-
-  def blacklisted
-    [sign_in_url, sign_up_url, user_confirmation, sign_password, cookies_allow]
-  end
-
-  def request_path_matches_any_of?(url_matchers)
-    url_matchers.any? { |url| url.match request.path }
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -26,53 +26,5 @@ describe Devise::SessionsController do
       post :create, 'user' => {'email' => 'example@example.com', 'password' => '12345'}
       expect(flash[:alert]).to have_content "I'm sorry, you are not authorized to login to the system."
     end
-
-    describe 'non-admins' do
-      describe 'associated with an organization LOGS IN' do
-        it 'redirects to organization page' do
-          Gmaps4rails.stub(:geocode)
-          org = FactoryGirl.create(:organization, {:email => 'example@example.com'})
-          FactoryGirl.build(:user, {:email => 'example@example.com', :password => 'pppppppp', :organization => org}).save!
-          post :create, 'user' => {'email' => 'example@example.com', 'password' => 'pppppppp'}
-          expect(response).to redirect_to organization_path(org.id)
-        end
-      end
-      describe 'associated with nothing LOGS IN' do
-        it 'redirects to previous page after non-admin associated with nothing logs-in from charity page' do
-          request.stub(:path).and_return(organization_path(1))
-          #session.stub(:previous_url).and_return(organization_path(1))
-          FactoryGirl.build(:user, {:email => 'example@example.com', :password => 'pppppppp'}).save!
-          post :create, 'user' => {'email' => 'example@example.com', 'password' => 'pppppppp'}
-          expect(response).to redirect_to organization_path(1)
-        end
-
-        it 'redirects to root after non-admin associated with nothing logs-in from sign in page' do
-          FactoryGirl.build(:user, {:email => 'example@example.com', :password => 'pppppppp'}).save!
-          post :create, 'user' => {'email' => 'example@example.com', 'password' => 'pppppppp'}
-          expect(response).to redirect_to root_url
-        end
-
-        it 'redirects to home page after non-admin associated with nothing logs-in' do
-          FactoryGirl.build(:user, {:email => 'example@example.com', :password => 'pppppppp'}).save!
-          post :create, 'user' => {'email' => 'example@example.com', 'password' => 'pppppppp'}
-          expect(response).to redirect_to root_url
-        end
-      end
-      describe 'associated with nothing FAILS TO LOG IN' do
-        it 'renders sign in page after non-admin associated with nothing fails to log-in' do
-          FactoryGirl.build(:user, {:email => 'example@example.com', :password => 'pppppppp'}).save!
-          post :create, 'user' => {'email' => 'example@example.com', 'password' => '12345'}
-          expect(response).to be_ok
-        end
-
-        it 'displays warning flash after non-admin associated with nothing fails to log-in' do
-          FactoryGirl.build(:user, {:email => 'example@example.com', :password => 'pppppppp'}).save!
-          post :create, 'user' => {'email' => 'example@example.com', 'password' => '12345'}
-          expect(flash[:alert]).to have_content "I'm sorry, you are not authorized to login to the system."
-        end
-      end
-    end
-
-
   end
 end


### PR DESCRIPTION
See title. White listing is a better solution because it's less likely that new features will secretly re-introduce redirect bugs.

Some tests were deleted because of the different / simpler implementation. (And also because those tests where just bad -- my fault.)
